### PR TITLE
fix: 兼容 DSH 0.1.2-rc.1（CallId → ToolCallId）+ 客户端构建外置 react-dom

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,9 +13,9 @@
       },
       "devDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-commands": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
-        "@deepseek-ai/dsh-tools": "^0.1.0-rc.6",
+        "@deepseek-ai/dsh-commands": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-rc.1",
         "@types/node": "^24.3.0",
         "@types/qrcode": "^1.5.5",
         "tsdown": "^0.22.14",
@@ -51,21 +51,21 @@
       }
     },
     "node_modules/@deepseek-ai/cordis": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/cordis/-/cordis-4.0.1.tgz",
-      "integrity": "sha512-YBdskTU2Po1kru3GgcUWUbkTsPMA9LkSQDAY8rBkFJeajdgcQad3QPJZE26JyK99Xb6HaASvoXg2DSUTeN/0Nw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/cordis/-/cordis-4.0.2.tgz",
+      "integrity": "sha512-asOnXP1TzFSFQlHb1iegDZp0z/8WD1c7YNrwJR/Tx2bzNuMXfcekE/I67Iv6SQXeLB4csxqCngzQKANP7gdw0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/cosmokit": "^1.8.2",
+        "@deepseek-ai/cosmokit": "^1.8.3",
         "@standard-schema/spec": "^1.1.0"
       },
       "bin": {
         "cordis": "bin.js"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis-plugin-include": "^1.0.6",
-        "@deepseek-ai/cordis-plugin-loader": "^1.0.2"
+        "@deepseek-ai/cordis-plugin-include": "^1.0.7",
+        "@deepseek-ai/cordis-plugin-loader": "^1.0.3"
       },
       "peerDependenciesMeta": {
         "@deepseek-ai/cordis-plugin-include": {
@@ -77,235 +77,271 @@
       }
     },
     "node_modules/@deepseek-ai/cosmokit": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/cosmokit/-/cosmokit-1.8.2.tgz",
-      "integrity": "sha512-muBOKtSrUKU5m/xpq8ZXWL6hQ/jgd4PhU2PqH97bcxIiLEJfNwZOGQEx4t/aS/GgxRAR+ra9pMHPMtTHU4sqqA==",
+      "version": "1.8.3",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/cosmokit/-/cosmokit-1.8.3.tgz",
+      "integrity": "sha512-qBo+ronVM6Eu2WNVJXi8JcMiqZ19T9BRIpV+5qJUFPXjGH/Z0QKcQMC/IZJ7L394YTOtJgcovbk9qP0w2GsBXQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@deepseek-ai/dsh-agent": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-agent/-/dsh-agent-0.1.0-rc.7.tgz",
-      "integrity": "sha512-AqBQavJYgbCUUYBHP7OGCaw8WN5082NXYQOoOfNRO72bub3E+/nWkl8b4B7BAJdFfyLo9ce+Kgb1BCHSJU/JLg==",
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-agent/-/dsh-agent-0.1.2-rc.1.tgz",
+      "integrity": "sha512-lfaqN34vUCWvbn1kJVHrhfJ6Dvt1HDHCm33ZCpmKkl07/5q6FxWqVv6rOdVX5QnM/9xz/uYiN0nQwUtBg4+Skg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-scope": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.7"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.2-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-attachment": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-attachment/-/dsh-attachment-0.1.0-rc.7.tgz",
-      "integrity": "sha512-rsR/xVNOGIig8gXxhrKnkd6YD7aYliGtA/e7b4DlPawMpLhsItAh0HQ832n8LJn1aGZxKf68y9PRgzfljsveOQ==",
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-attachment/-/dsh-attachment-0.1.2-rc.1.tgz",
+      "integrity": "sha512-QISKUjEITusLvAkqPLRn70xDUt+GjjY41pISjtPKYcZ4EGmayzhgZ3VJNYEcC+rbaF44hs2o/0VhOwHA7lyxjw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-brand": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-brand/-/dsh-brand-0.1.0-rc.7.tgz",
-      "integrity": "sha512-P7+w0fN40yXXQkV360p6jQi63pcl68OOWebNGN5gf8w8sguvni2mA1cU8RLZzDkRNFSZD+BCw3D4uWYM+hhh7A==",
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-brand/-/dsh-brand-0.1.2-rc.1.tgz",
+      "integrity": "sha512-y2RHIag3kzLdY8kTBuSUSTsKzWPscJrysNObXTiNM7stXLpa3jXpshsB1caqGzNx50vYcmHeN1gFVECgx3NZHg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
+        "@deepseek-ai/cordis": "^4.0.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-code-runtime": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-code-runtime/-/dsh-code-runtime-0.1.0-rc.7.tgz",
-      "integrity": "sha512-vzW82eU4so0qJQ/XS7BGBUSguJMAgEOW3GaJJW0g+W5ysBJg+UC/Jjo1Np8mPjSpjjl4eoyXpshJzrwjoxCpRg==",
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-code-runtime/-/dsh-code-runtime-0.1.2-rc.1.tgz",
+      "integrity": "sha512-dv5UszPJb/AFcarZc2c6h5z/X80bsrSd3bfIOugwNVclSI6P+L3ixseoZKgyks7T0Ap0h6ngXGk2WeoUkmYxnQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
+        "@deepseek-ai/cordis": "^4.0.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-commands": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-commands/-/dsh-commands-0.1.0-rc.7.tgz",
-      "integrity": "sha512-SYrQpJZQ4fvfyfw3IJ5j0goUiOFZb1ZhcANgUp99HVlhhN/l1oEOAvEZL1efaSE7KIG6qp4JEn7iLtNdo8+mEA==",
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-commands/-/dsh-commands-0.1.2-rc.1.tgz",
+      "integrity": "sha512-uBh4JTX7pOkFhmbWjXjVLnOQOawyccC7+DazbHrLRN6/wy4OgTRH+DaW0+ibLq+XRAO19OvBTtuoh3x/KkJx1Q==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-util-crypto": "^0.1.2-rc.1",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-attachment": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-invariants": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-invariants/-/dsh-invariants-0.1.2-rc.1.tgz",
+      "integrity": "sha512-zSjuFJYcEB94kPwn7SicqAV1dfVWZkjt1I8luDboxtjfp5CN6ziwJhLv3KaB+Dh9tgkyGY4mvo886W/HhE9L9g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-llm": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-llm/-/dsh-llm-0.1.2-rc.1.tgz",
+      "integrity": "sha512-7VYsha5AXsVLnsAwYJffWXz9bwUbElw8i5N8tlTSdai9Bupk3sMbsotzPf8ZbsuGAxQYErahMwQwgGEu4qZO6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-timeout": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-util-crypto": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-scope": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-scope/-/dsh-scope-0.1.2-rc.1.tgz",
+      "integrity": "sha512-GHwbzWrGbmE0ZGzAZsXBudpyCM9ENCpXxlKODIaPFbIWhRePh6nH2jW47TAOqCIsPPedWC2p3w8Tx5WAa3I/2A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-session": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session/-/dsh-session-0.1.2-rc.1.tgz",
+      "integrity": "sha512-jRGNPTbQcvIx1F2MVmmkoiHLgpC3Btqo1wkl/3JDLlOWRVWKOuaC+5fQiMrFPOYfno6YiX/c2UvmA0td8qB92w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-session-projection": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-projection/-/dsh-session-projection-0.1.2-rc.1.tgz",
+      "integrity": "sha512-qVWlIzPm4u9vzQ5G/QtE6jeSJ3b3b42hWVJj664BurEZlHbAfdqkhYc1QsoBU+5k5kUEJFHh07z8HxuXA9kTnQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
       "dependencies": {
         "zod": "^4.4.3"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-scope": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.7"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-invariants": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-invariants/-/dsh-invariants-0.1.0-rc.7.tgz",
-      "integrity": "sha512-PnO1F4aZGUmqZPyuPJpBUfQ4DZmjCGCNGr0yuN2iURTP/e6h0kGnTNTYgR2NqMvAtpP66WNiHhvH2LMqumk1+A==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-llm": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-llm/-/dsh-llm-0.1.0-rc.7.tgz",
-      "integrity": "sha512-VaB9kQ8XOA+R5jtsWf92QMc1WpaatEAFUvQePGUYrzQ7Z86b9VhQQzmchh5VmknT4oRSSdn0re5tReCvfcYNXQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-attachment": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-timeout": "^0.1.0-rc.7"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-scope": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-scope/-/dsh-scope-0.1.0-rc.7.tgz",
-      "integrity": "sha512-8gn+sANXhpv+9egbNwq49/uI3XhbmB33obo9yMyzyzruan3zFoxeH4UV54jTC2hjbu8gFNPsyNam9AAtRV8/Cg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-session": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session/-/dsh-session-0.1.0-rc.7.tgz",
-      "integrity": "sha512-02WVTkqIH+TyDL7dhMN3Hm+qcTEdhD0fVDC0aIAyND2fBdXj3CagEXXvpmt3mzwWfKwOTGL1RdxtC6pMA4Bl1A==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-scope": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.7"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-system-prompt": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-system-prompt/-/dsh-system-prompt-0.1.0-rc.7.tgz",
-      "integrity": "sha512-Rair2ZkzgoIIr+UstYVYeqeUgORNPIW1LNcsXz3Zjglx4FGjsmzs0UALdNYvSBpBvCLNmt4E6+XQIrBbS/s9jw==",
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-system-prompt/-/dsh-system-prompt-0.1.2-rc.1.tgz",
+      "integrity": "sha512-7W93PZKIk4CHvjZGgLIxrrEKpk+6t8nQXje1vKR5vG73dfXH0t1MJ5WWH/fngadYc7c6KzM84ihQ66tJqJqyNQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/schemastery": "^3.18.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-scope": "^0.1.0-rc.7"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-timeout": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-timeout/-/dsh-timeout-0.1.0-rc.7.tgz",
-      "integrity": "sha512-Ufl9G7zP7Tky/zkXscavEiolEfAwutfbPeLb5sUU/tPQlDykhh1NwGrarNJ11fdR723zmA/3co4LgxtDtWCOEQ==",
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-timeout/-/dsh-timeout-0.1.2-rc.1.tgz",
+      "integrity": "sha512-llz11yxWeJB8suKCa6hRLjNBWVaPn3Fbd0XoBS0bkZLhPFzO1mDorx/XMca2GhI7XF9A86CURQcDt+aGjjvqJA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
+        "@deepseek-ai/cordis": "^4.0.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-tools": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tools/-/dsh-tools-0.1.0-rc.7.tgz",
-      "integrity": "sha512-7Kq3EEv354aNcxbS0NRfxxyJiZhCsvFV/03a3MdkYO/gG2eM9+E4xQum0N2FL5bw7JiGlgw8jdLMkcNGmavEaA==",
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tools/-/dsh-tools-0.1.2-rc.1.tgz",
+      "integrity": "sha512-W9kUio00s7WbM8kEwniyd4hfb3CeUxVczsjXbOcKtakfiTywNLeyRWkpx2fvwRAH2rBfg3qCgczVfS0DOw1csg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-code-runtime": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-scope": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-user-approval": "^0.1.0-rc.7"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-code-runtime": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-user-approval": "^0.1.2-rc.1"
       }
     },
     "node_modules/@deepseek-ai/dsh-typert-protocol": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-typert-protocol/-/dsh-typert-protocol-0.1.0-rc.7.tgz",
-      "integrity": "sha512-R7qdvaRRHbz5xijoVOxueeBB/VT0eDzuQNQN4iNEBUbI/L9xG9bZutktTQlgrIlBSn1sPH4pLqiCiM6ErQPTaQ==",
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-typert-protocol/-/dsh-typert-protocol-0.1.2-rc.1.tgz",
+      "integrity": "sha512-vBWD0NpriPd96ltbWaAw+iKeWFIEjiAcCWYtmqEcV1Ms+FaV02usjjm7LCmhSQhMZpBSBc7EZUX0spGlpjI1bA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
+        "@deepseek-ai/cordis": "^4.0.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-user-approval": {
-      "version": "0.1.0-rc.7",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-user-approval/-/dsh-user-approval-0.1.0-rc.7.tgz",
-      "integrity": "sha512-kYMpU6eg1m1BcfSC4FLWUcNH/QAE8tcu0WRkQzqzoCw8bK/Nl3dqHtd2qSVzI/emIviTulM5I230e4wPi/kuVg==",
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-user-approval/-/dsh-user-approval-0.1.2-rc.1.tgz",
+      "integrity": "sha512-oYkLE4a/TwqVNi299pUf/QP1Yku6KScdUCTUyYbjaRBcN+/pXPpHikl2aoE2thH9D0uT/Kj6T2kz+wDDcFd9Xg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/schemastery": "^3.18.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-brand": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-scope": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.7"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-util-crypto": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-util-crypto/-/dsh-util-crypto-0.1.2-rc.1.tgz",
+      "integrity": "sha512-gE8FznQ1hkknw9QMrHNSlm3UEyRYuj3MLVvlJ6NyH1kmOsdjnbrVbSs+Pn72k2oIV4Fiyu3Umg0sLznUEcsiXw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-util-values": {
+      "version": "0.1.2-rc.1",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-util-values/-/dsh-util-values-0.1.2-rc.1.tgz",
+      "integrity": "sha512-FQdgoK+KYVR0pBQb9fTsajvGb3gzUxEzJQEYnFOt+Qdwc4nkxJOPwJJdIvXuqvZaQ33DaOoqpnpcr2p5HpLu4g==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
       }
     },
     "node_modules/@deepseek-ai/schemastery": {
-      "version": "3.18.1",
-      "resolved": "https://registry.npmmirror.com/@deepseek-ai/schemastery/-/schemastery-3.18.1.tgz",
-      "integrity": "sha512-Qn0FCSwCQnpnj6SB31I6i2sIKgKWnkbJM8O0EU91Gv2UsYVvtZTl6IA0sCwk2e2MZf5S8w5hpq9QkeVvK9qwxg==",
+      "version": "3.18.2",
+      "resolved": "https://registry.npmmirror.com/@deepseek-ai/schemastery/-/schemastery-3.18.2.tgz",
+      "integrity": "sha512-njDtZsznjYxok7KLLlHOPyuv2efdWVbSflAHgztSfbMsg+CVraEoRe2DjOCgClYv3ZCSm7WXoaUkbB/+RY7tWQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/cosmokit": "^1.8.2",
+        "@deepseek-ai/cosmokit": "^1.8.3",
         "@standard-schema/spec": "^1.1.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -52,9 +52,9 @@
   },
   "devDependencies": {
     "@deepseek-ai/cordis": "^4.0.1",
-    "@deepseek-ai/dsh-commands": "^0.1.0-rc.6",
-    "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
-    "@deepseek-ai/dsh-tools": "^0.1.0-rc.6",
+    "@deepseek-ai/dsh-commands": "^0.1.2-rc.1",
+    "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
+    "@deepseek-ai/dsh-tools": "^0.1.2-rc.1",
     "@types/node": "^24.3.0",
     "@types/qrcode": "^1.5.5",
     "tsdown": "^0.22.14",

--- a/src/host/mapper.ts
+++ b/src/host/mapper.ts
@@ -14,7 +14,7 @@
 // derived cursor. Text/reasoning streaming and the result envelope behave
 // as before; thinking-only turns stay token-annotated because agy print
 // mode never streams the thoughts themselves.
-import { CallId, type StreamChunk, type TokenUsage } from '@deepseek-ai/dsh-llm'
+import { ToolCallId, type StreamChunk, type TokenUsage } from '@deepseek-ai/dsh-llm'
 import type { AgyEvent, RawUsage } from '../common/types.ts'
 import { mirrorCallId } from './recording.ts'
 import { buildMirrorRunCode, MIRROR_TOOL_NAME, WRAPPER_TOOL_NAME } from './mirror-tool.ts'
@@ -230,7 +230,7 @@ export class EventMapper {
           index: idx,
           block: {
             type: 'tool-call',
-            id: CallId(mirrorCallId(this.opts.runId, absIndex)),
+            id: ToolCallId(mirrorCallId(this.opts.runId, absIndex)),
             name: toolName,
             arguments: argumentsJson,
           },

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -48,7 +48,7 @@ export default defineConfig([
     dts: false,
     clean: false,
     fixedExtension: false,
-    external: [/^@deepseek-ai\//, "react"],
+    external: [/^@deepseek-ai\//, "react", "react-dom", "react/jsx-runtime"],
     outputOptions: {
       entryFileNames: "client.js",
       banner: `window.__ModuleLoader__.load({ id: "dsh-agy-link", factory: (require) => {`,


### PR DESCRIPTION
## 简介

修复与当前 DSH 运行时（dsh-llm `0.1.2-rc.1`）的两处**崩溃级**不兼容问题。两者都会导致插件树加载失败——host 端是静态导入错误，client 端是缺少全局变量。

## 问题一 — host 端加载崩溃（`CallId` 从 dsh-llm 移除）

dsh-llm `>= 0.1.1-rc.x` 把导出的 brand 助手 `CallId` 改名为 `ToolCallId`，而 `0.1.2-rc.1` **完全移除了 `CallId`**。插件对它的 ESM 导入导致整个 loader entry 失败：

```
SyntaxError: The requested module '@deepseek-ai/dsh-llm' does not provide an export named 'CallId'
```

**修复：** 改导入 `ToolCallId`。向后兼容：在旧版 dsh-llm 中两者是结构完全一致的 `brandString` 包装器，生成的 tool-call 块 id 不变。

## 问题二 — client 端加载崩溃（浏览器里 `process is not defined`）

客户端用 tsdown 构建，externals 里只列了 `react`。由于 `react-dom` 未标记 external，打包器把 React 的开发版（含 `process.env.NODE_ENV` 检查）内联进了 `dist/client.js`。浏览器没有 `process` 全局，于是 ModuleLoader 抛 `process is not defined`，浏览器 UI 显示 *Failed to load plugins*。

**修复：** 把 `react-dom` 和 `react/jsx-runtime` 加进客户端 externals，让 DSH 的客户端运行时提供它们。产物与发布构建大小一致（`57.6 kB`，零 `process` 引用）。

## 版本对齐

devDependencies + `package-lock.json` 固定到 `@deepseek-ai/dsh-*` `0.1.2-rc.1`，让类型检查的契约与运行时一致（`tsc` 能看到 `ToolCallId`）。

## 验证

本仓库 CI 链路本地通过（`npm ci` → `npm run check` → `npm run build` → `npm test`）：

- `tsc --noEmit`：通过
- 构建：`dist/client.js` 57.6 kB，`dist/index.js` 1.18 MB
- 测试：**151/151 通过**

## 维护者备注

- 上游 lockfile 锁在 `0.1.0-rc.7`（仍导出 `CallId`），所以这个不兼容在 CI 里没暴露，直到消费方在 `0.1.2-rc.1` 上运行才出现。
- `react-dom` 被打包同样是环境相关的（只有当构建时能解析到 `react-dom` 才咬人），所以无论上游是否采纳版本升级，都建议把 `react-dom` 加入客户端 externals。
